### PR TITLE
Make TodoCommand an unsigned 8-bit int

### DIFF
--- a/todo/parse.go
+++ b/todo/parse.go
@@ -150,9 +150,6 @@ func parseLine(line string, commentChar byte) (Todo, error) {
 }
 
 func isCommand(i TodoCommand, s string) bool {
-	if i < 0 || i > Comment {
-		return false
-	}
 	return len(s) > 0 &&
 		(todoCommandInfo[i].cmd == s || todoCommandInfo[i].nickname == s)
 }

--- a/todo/todo.go
+++ b/todo/todo.go
@@ -1,6 +1,6 @@
 package todo
 
-type TodoCommand int
+type TodoCommand uint8
 
 const (
 	Pick TodoCommand = iota + 1


### PR DESCRIPTION
This helps with better packing of structs that have this as a field, along with
other fields that are less than four bytes. Lazygit's models.Commit struct is an
example.